### PR TITLE
Add support for result.success & completion

### DIFF
--- a/js/h5p-x-api-event.js
+++ b/js/h5p-x-api-event.js
@@ -18,18 +18,40 @@ H5P.XAPIEvent.prototype.constructor = H5P.XAPIEvent;
  *
  * @param {number} score
  * @param {number} maxScore
+ * @param {object} instance
+ * @param {boolean} completion
+ * @param {boolean} success
  */
-H5P.XAPIEvent.prototype.setScoredResult = function (score, maxScore, instance) {
-  this.data.statement.result = {
-    'score': {
-      'min': 0,
-      'max': maxScore,
-      'raw': score
+H5P.XAPIEvent.prototype.setScoredResult = function (score, maxScore, instance, completion, success) {
+  this.data.statement.result = {};
+  
+  if (typeof score !== 'undefined') {
+    if (typeof maxScore === 'undefined') {
+      this.data.statement.result.score = {'raw': score};
     }
-  };
-  if (maxScore > 0) {
-    this.data.statement.result.score.scaled = Math.round(score / maxScore * 10000) / 10000;
+    else {
+      this.data.statement.result.score = {
+        'min': 0,
+        'max': maxScore,
+        'raw': score
+      };
+      if (maxScore > 0) {
+        this.data.statement.result.score.scaled = Math.round(score / maxScore * 10000) / 10000;
+      }
+    }
   }
+  
+  if (typeof completion === 'undefined') {
+    this.data.statement.result.completion = true;
+  }
+  else {
+    this.data.statement.result.completion = completion;
+  }
+  
+  if (typeof success !== 'undefined') {
+    this.data.statement.result.success = success;
+  }
+  
   if (instance && instance.activityStartTime) {
     var duration = Math.round((Date.now() - instance.activityStartTime ) / 10) / 100;
     // xAPI spec allows a precision of 0.01 seconds

--- a/js/h5p-x-api.js
+++ b/js/h5p-x-api.js
@@ -65,9 +65,16 @@ H5P.EventDispatcher.prototype.createXAPIEventTemplate = function (verb, extra) {
  *   Will be set as the 'raw' value of the score object
  * @param {number} maxScore
  *   will be set as the "max" value of the score object
+ * @param {boolean} success
+ *   will be set as the "success" value of the result object
  */
-H5P.EventDispatcher.prototype.triggerXAPICompleted = function (score, maxScore) {
-  this.triggerXAPIScored(score, maxScore, 'completed');
+H5P.EventDispatcher.prototype.triggerXAPICompleted = function (score, maxScore, success) {
+  var verb = 'completed';
+  if (typeof success !== 'undefined') {
+    if (success) {verb = "passed";}
+    else {verb = "failed";}
+  }
+  this.triggerXAPIScored(score, maxScore, verb, true, success);
 };
 
 /**
@@ -80,9 +87,9 @@ H5P.EventDispatcher.prototype.triggerXAPICompleted = function (score, maxScore) 
  * @param {string} verb
  *   Short form of adl verb
  */
-H5P.EventDispatcher.prototype.triggerXAPIScored = function (score, maxScore, verb) {
+H5P.EventDispatcher.prototype.triggerXAPIScored = function (score, maxScore, verb, completion, success) {
   var event = this.createXAPIEventTemplate(verb);
-  event.setScoredResult(score, maxScore, this);
+  event.setScoredResult(score, maxScore, this, completion, success);
   this.trigger(event);
 };
 


### PR DESCRIPTION
This PR 
* Adds optional completion and success parameters to the setScoredResult method. These can be used to set the statement's result.success and result.completion properties. Completion defaults to true if the parameter is not passed. 
* Makes score and max score optional in case these properties are not relevant for a statement (e.g. maybe only duration and completion are needed). 

This code has not been tested in any way. Is there a recommended way to test H5P code changes? 

Fixes https://github.com/h5p/h5p-php-library/issues/2