### PR TITLE
Adds minimal composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,10 @@
+{
+    "name": "h5p/h5p-php-library",
+    "license": "GPL-3.0",
+    "autoload": {
+        "files": [
+        	"h5p-development.class.php",
+        	"h5p.classes.php"
+        ]
+    }
+}


### PR DESCRIPTION
Currently the library code is being added to frameworks as a git submodule. This PR would allow installing the library also as a [composer](https://getcomposer.org/) dependency.