### PR TITLE
LTR/RTL directionality support

### DIFF
--- a/js/h5p.js
+++ b/js/h5p.js
@@ -111,6 +111,9 @@ H5P.init = function (target) {
       params: JSON.parse(contentData.jsonContent)
     };
 
+    // Add dir-ltr|rtl to h5p-content div, based on iframe parent document directionality.
+    $element.addClass('dir-' + window.parent.document.dir);
+
     H5P.getUserData(contentId, 'state', function (err, previousState) {
       if (previousState) {
         library.userDatas = {


### PR DESCRIPTION
Add dir-ltr|rtl to h5p-content div, based on iframe parent document directionality.
(Which will help us address proper rtl alignment and directionality css selectors, in future patches)

Fix is only needed for iframe embedding. as parent document directionality is already available to div embedding.
