### PR TITLE
don't fail silently in createExportFile

### DIFF
--- a/h5p-default-storage.class.php
+++ b/h5p-default-storage.class.php
@@ -132,11 +132,18 @@ class H5PDefaultStorage implements \H5PFileStorage {
    *  Path on file system to temporary export file.
    * @param string $filename
    *  Name of export file.
+   * @throws Exception Unable to save the file
    */
   public function saveExport($source, $filename) {
     $this->deleteExport($filename);
-    self::dirReady("{$this->path}/exports");
-    copy($source, "{$this->path}/exports/{$filename}");
+
+    if (!self::dirReady("{$this->path}/exports")) {
+      throw new Exception("Unable to create directory for H5P export file.");
+    }
+
+    if (!copy($source, "{$this->path}/exports/{$filename}")) {
+      throw new Exception("Unable to save H5P export file.");
+    }
   }
 
   /**

--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -1595,6 +1595,7 @@ Class H5PExport {
     }
     catch (Exception $e) {
       $this->h5pF->setErrorMessage($this->h5pF->t($e->getMessage()));
+      return false;
     }
 
     unlink($tmpFile);


### PR DESCRIPTION
I made these updates:

* In `H5PDefaultStorage::saveExport` an exception is thrown if the export directory can't be created or if the export file can't be written.
* `H5PExport::createExportFile` doesn't silently "eat" the exception, but actually returns FALSE if the file can't be exported.

There were cases before where `H5PExport::createExportFile` could fail and return FALSE, so adding one more case where it can fail and return FALSE doesn't change the semantics of that function. 

There is only one call to `H5PExport::createExportFile`, and that is from `H5PCore::filterParameters`. This call does not check the return value from `H5PExport::createExportFile`. Ideally it should, but currently there is no way `H5PCore::filterParameters` can fail gracefully. Returning FALSE would not make sense. The return value from `H5PCore::filterParameters` is used in a few places, but the value is never checked if it is FALSE. I tried to make `H5PCore::filterParameters` return false, and it caused all sort of random errors.

So the conclusion is that I think the best thing to do for now is to leave it with the additions I made, and not let the error propagate any further. It is not ideal, but at least there is a bit more error handling than before.

The end user experience with these additions is that an error message is shown if the export file can't be created, where before this was just completely silently ignored. 