### PR TITLE
Check for file exists before adding to zip.

### DIFF
--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -1586,8 +1586,8 @@ Class H5PExport {
     foreach ($files as $file) {
       // Please note that the zip format has no concept of folders, we must
       // use forward slashes to separate our directories.
-      $zip->addFile($file->absolutePath, $file->relativePath);
-      $zip->addFile($rootPrefix . $file->absolutePath, $file->relativePath);
+      if (file_exists($file->absolutePath)) $zip->addFile($file->absolutePath, $file->relativePath);
+      if (file_exists($rootPrefix . $file->absolutePath)) $zip->addFile($rootPrefix . $file->absolutePath, $file->relativePath);
     }
 
     // Close zip and remove tmp dir


### PR DESCRIPTION
Adding a non existent file to ZipArchive can lead to archive not being created

http://biostall.com/php-ziparchive-class-not-creating-zip-file-and-no-errors/

error occured on a windows host with iis webserver and php 5.4.4
Using h5p in combination with moodle plugin on moodle 2.8.9
