### PR TITLE
Fixed iOS bug for Image Hotspots and iFrames

### DIFF
--- a/styles/h5p.css
+++ b/styles/h5p.css
@@ -147,7 +147,9 @@ div.h5p-fullscreen {
   z-index: 20;
 }
 .h5p-iframe-wrapper iframe.h5p-iframe {
-  width: 100%;
+  width: 10px;
+  min-width: 100%;
+  *width: 100%;
   height: 100%;
   z-index: 10;
   overflow: hidden;


### PR DESCRIPTION
There is a bug in iOS with IFrame's that when changing orientation width: 100% stays at landscape rather than going back to portrait. https://bugs.webkit.org/show_bug.cgi?id=155198. Tested on iOS 10 iPhone 7 on image hotspot.