### PR TITLE
Avoid accidently selecting things in the toolbar

### DIFF
--- a/js/h5p-action-bar.js
+++ b/js/h5p-action-bar.js
@@ -36,7 +36,7 @@ H5P.ActionBar = (function ($, EventDispatcher) {
         self.trigger(type);
       };
       H5P.jQuery('<li/>', {
-        'class': 'h5p-button h5p-' + (customClass ? customClass : type),
+        'class': 'h5p-button h5p-noselect h5p-' + (customClass ? customClass : type),
         role: 'button',
         tabindex: 0,
         title: H5P.t(type + 'Description'),

--- a/styles/h5p.css
+++ b/styles/h5p.css
@@ -35,7 +35,6 @@ html.h5p-iframe, html.h5p-iframe > body {
   -khtml-user-select: none;
   -ms-user-select: none;
   -moz-user-select: none;
-  -webkit-touch-callout: none;
   -webkit-user-select: none;
   user-select: none;
 }

--- a/styles/h5p.css
+++ b/styles/h5p.css
@@ -30,6 +30,15 @@ html.h5p-iframe, html.h5p-iframe > body {
   box-sizing: border-box;
   -moz-box-sizing: border-box;
 }
+.h5p-noselect
+{
+  -khtml-user-select: none;
+  -ms-user-select: none;
+  -moz-user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
 html.h5p-iframe .h5p-content {
   font-size: 16px;
   line-height: 1.5em;


### PR DESCRIPTION
This will prevent actionbar buttons from being selectable as described in [HFP-878](https://h5ptechnology.atlassian.net/browse/HFP-878).

Alternatively, the CSS arguments could have been added to the h5p-button class directly, but the class could possibly be used by other elements as well.

Successfully tested with Chrome, IE and Firefox.