### PR TITLE
Fixing font-family regex pattern when validating text

### DIFF
--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -3163,7 +3163,7 @@ class H5PContentValidator {
           $stylePatterns[] = '/^font-size: *[0-9.]+(em|px|%) *;?$/i';
         }
         if (isset($semantics->font->family) && $semantics->font->family) {
-          $stylePatterns[] = '/^font-family: *[a-z0-9," ]+;?$/i';
+          $stylePatterns[] = '/^font-family: *[-a-z0-9," ]+;?$/i';
         }
         if (isset($semantics->font->color) && $semantics->font->color) {
           $stylePatterns[] = '/^color: *(#[a-f0-9]{3}[a-f0-9]{3}?|rgba?\([0-9, ]+\)) *;?$/i';


### PR DESCRIPTION
Some font-family also contains the minus sign (-) in their names and the regex that validates this is missing the minus sign.
e.g. sans-serif