### PR TITLE
Prints optional additonal head tags in embed.php

### DIFF
--- a/embed.php
+++ b/embed.php
@@ -9,6 +9,7 @@
   <?php for ($i = 0, $s = count($styles); $i < $s; $i++): ?>
     <link rel="stylesheet" href="<?php print $styles[$i]; ?>">
   <?php endfor; ?>
+  <?php if (isset($additional_embed_head_tags)) { print implode("\n", $additional_embed_head_tags); } ?>
 </head>
 <body>
   <div class="h5p-content" data-content-id="<?php print $content['id']; ?>"></div>


### PR DESCRIPTION
Works in conjunction with modifications to class-h5p-php-admin.php
in the core h5p plugin. Allows other plugins to add code to be
inserted into the head of the embeded iframe generated by embed.php.

See discussion of this issue here:
https://github.com/h5p/h5p-wordpress-plugin/issues/58#issuecomment-337906304