### PR TITLE
BUGFIX: Fix capitalization of the "Content-Type" HTTP header

### DIFF
--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -2881,7 +2881,7 @@ class H5PCore {
    */
   private static function printJson($data, $status_code = NULL) {
     header('Cache-Control: no-cache');
-    header('Content-type: application/json; charset=utf-8');
+    header('Content-Type: application/json; charset=utf-8');
     print json_encode($data);
   }
 


### PR DESCRIPTION
The "Content-Type" header is capitalized incorrectly. This can lead to unexpected behaviour when parsing responses (e.g. JSON being loaded as strings instead of objects by the JS engine). See https://tools.ietf.org/html/rfc7231#section-3.1.1.5.