### PR TITLE
Replaced DIRECTORY_SEPARATOR

### DIFF
--- a/h5p-default-storage.class.php
+++ b/h5p-default-storage.class.php
@@ -373,7 +373,7 @@ class H5PDefaultStorage implements \H5PFileStorage {
       $target = "{$this->path}/content/{$contentId}";
     }
 
-    $contentSource = $source . DIRECTORY_SEPARATOR . 'content';
+    $contentSource = $source . '/' . 'content';
     $contentFiles = array_diff(scandir($contentSource), array('.','..', 'content.json'));
     foreach ($contentFiles as $file) {
       if (is_dir("{$contentSource}/{$file}")) {
@@ -445,8 +445,8 @@ class H5PDefaultStorage implements \H5PFileStorage {
    * @return bool
    */
   public function hasPresave($libraryFolder, $developmentPath = null) {
-      $path = is_null($developmentPath) ? 'libraries' . DIRECTORY_SEPARATOR . $libraryFolder : $developmentPath;
-      $filePath = realpath($this->path . DIRECTORY_SEPARATOR . $path . DIRECTORY_SEPARATOR . 'presave.js');
+      $path = is_null($developmentPath) ? 'libraries' . '/' . $libraryFolder : $developmentPath;
+      $filePath = realpath($this->path . '/' . $path . '/' . 'presave.js');
     return file_exists($filePath);
   }
 

--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -933,7 +933,7 @@ class H5PValidator {
       // Process and validate libraries using the unpacked library folders
       $files = scandir($tmpDir);
       foreach ($files as $file) {
-        $filePath = $tmpDir . DIRECTORY_SEPARATOR . $file;
+        $filePath = $tmpDir . '/' . $file;
 
         if ($file === '.' || $file === '..' || $file === 'content' || !is_dir($filePath)) {
           continue; // Skip
@@ -1102,14 +1102,14 @@ class H5PValidator {
       $this->h5pF->setErrorMessage($this->h5pF->t('Invalid library name: %name', array('%name' => $file)), 'invalid-library-name');
       return FALSE;
     }
-    $h5pData = $this->getJsonData($filePath . DIRECTORY_SEPARATOR . 'library.json');
+    $h5pData = $this->getJsonData($filePath . '/' . 'library.json');
     if ($h5pData === FALSE) {
       $this->h5pF->setErrorMessage($this->h5pF->t('Could not find library.json file with valid json format for library %name', array('%name' => $file)), 'invalid-library-json-file');
       return FALSE;
     }
 
     // validate json if a semantics file is provided
-    $semanticsPath = $filePath . DIRECTORY_SEPARATOR . 'semantics.json';
+    $semanticsPath = $filePath . '/' . 'semantics.json';
     if (file_exists($semanticsPath)) {
       $semantics = $this->getJsonData($semanticsPath, TRUE);
       if ($semantics === FALSE) {
@@ -1122,7 +1122,7 @@ class H5PValidator {
     }
 
     // validate language folder if it exists
-    $languagePath = $filePath . DIRECTORY_SEPARATOR . 'language';
+    $languagePath = $filePath . '/' . 'language';
     if (is_dir($languagePath)) {
       $languageFiles = scandir($languagePath);
       foreach ($languageFiles as $languageFile) {
@@ -1133,7 +1133,7 @@ class H5PValidator {
           $this->h5pF->setErrorMessage($this->h5pF->t('Invalid language file %file in library %library', array('%file' => $languageFile, '%library' => $file)), 'invalid-language-file');
           return FALSE;
         }
-        $languageJson = $this->getJsonData($languagePath . DIRECTORY_SEPARATOR . $languageFile, TRUE);
+        $languageJson = $this->getJsonData($languagePath . '/' . $languageFile, TRUE);
         if ($languageJson === FALSE) {
           $this->h5pF->setErrorMessage($this->h5pF->t('Invalid language file %languageFile has been included in the library %name', array('%languageFile' => $languageFile, '%name' => $file)), 'invalid-language-file');
           return FALSE;
@@ -1144,7 +1144,7 @@ class H5PValidator {
     }
 
     // Check for icon:
-    $h5pData['hasIcon'] = file_exists($filePath . DIRECTORY_SEPARATOR . 'icon.svg');
+    $h5pData['hasIcon'] = file_exists($filePath . '/' . 'icon.svg');
 
     $validLibrary = $this->isValidH5pData($h5pData, $file, $this->libraryRequired, $this->libraryOptional);
 
@@ -1228,8 +1228,8 @@ class H5PValidator {
    */
   private function isExistingFiles($files, $tmpDir, $library) {
     foreach ($files as $file) {
-      $path = str_replace(array('/', '\\'), DIRECTORY_SEPARATOR, $file['path']);
-      if (!file_exists($tmpDir . DIRECTORY_SEPARATOR . $library . DIRECTORY_SEPARATOR . $path)) {
+      $path = str_replace(array('/', '\\'), '/', $file['path']);
+      if (!file_exists($tmpDir . '/' . $library . '/' . $path)) {
         $this->h5pF->setErrorMessage($this->h5pF->t('The file "%file" is missing from library: "%name"', array('%file' => $path, '%name' => $library)), 'library-missing-file');
         return FALSE;
       }
@@ -1520,7 +1520,7 @@ class H5PStorage {
 
     if (!$skipContent) {
       $basePath = $this->h5pF->getUploadedH5pFolderPath();
-      $current_path = $basePath . DIRECTORY_SEPARATOR . 'content';
+      $current_path = $basePath . '/' . 'content';
 
       // Save content
       if ($content === NULL) {
@@ -1539,7 +1539,7 @@ class H5PStorage {
         }
       }
 
-      $content['params'] = file_get_contents($current_path . DIRECTORY_SEPARATOR . 'content.json');
+      $content['params'] = file_get_contents($current_path . '/' . 'content.json');
 
       if (isset($options['disable'])) {
         $content['disable'] = $options['disable'];
@@ -1911,7 +1911,7 @@ Class H5PExport {
    */
   private static function populateFileList($dir, &$files, $relative = '') {
     $strip = strlen($dir) + 1;
-    $contents = glob($dir . DIRECTORY_SEPARATOR . '*');
+    $contents = glob($dir . '/' . '*');
     if (!empty($contents)) {
       foreach ($contents as $file) {
         $rel = $relative . substr($file, $strip);
@@ -3696,7 +3696,7 @@ class H5PContentValidator {
     $wl_regex = '/\.(' . preg_replace('/ +/i', '|', preg_quote($whitelist)) . ')$/i';
 
     foreach ($files as $file) {
-      $filePath = $contentPath . DIRECTORY_SEPARATOR . $file;
+      $filePath = $contentPath . '/' . $file;
       if (is_dir($filePath)) {
         $valid = $this->validateContentFiles($filePath, $isLibrary) && $valid;
       }


### PR DESCRIPTION
DIRECTORY_SEPARATOR is not supposed to be used to compose paths; it is supposed to be used with rtrim and other operations on paths handed to you by the system.
All PHP running platforms support '/' as path separator.