### PR TITLE
Add toggler view others contents

### DIFF
--- a/js/h5p-data-view.js
+++ b/js/h5p-data-view.js
@@ -430,12 +430,11 @@ var H5PDataView = (function ($) {
       'class': 'h5p-others-contents-toggler-label',
       'text': this.l10n.showOwnContentOnly,
       'for': 'h5p-others-contents-toggler'
-    });
+    }).prepend(this.$othersContentToggler);
 
     $('<div>', {
       'class': 'h5p-others-contents-toggler-wrapper'
-    }).append(this.$othersContentToggler)
-      .append($label)
+    }).append($label)
       .appendTo(this.$container);
   };
 

--- a/js/h5p-data-view.js
+++ b/js/h5p-data-view.js
@@ -53,7 +53,17 @@ var H5PDataView = (function ($) {
     self.filterOn = [];
     self.facets = {};
 
-    self.loadData();
+    // Index of column with author name; could be made more general by passing database column names and checking for position
+    self.columnIdAuthor = 2;
+
+    // Future option: Create more general solution for filter presets
+    if (H5PIntegration.user && parseInt(H5PIntegration.user.canToggleViewOthersH5PContents) === 1) {
+      self.updateTable([]);
+      self.filterByFacet(self.columnIdAuthor, H5PIntegration.user.id, H5PIntegration.user.name || '');
+    }
+    else {
+      self.loadData();
+    }
   }
 
   /**
@@ -151,6 +161,12 @@ var H5PDataView = (function ($) {
       // Add filters
       self.addFilters();
 
+      // Add toggler for others' content
+      if (H5PIntegration.user && parseInt(H5PIntegration.user.canToggleViewOthersH5PContents) > 0) {
+        // canToggleViewOthersH5PContents = 1 is setting for only showing current user's contents
+        self.addOthersContentToggler(parseInt(H5PIntegration.user.canToggleViewOthersH5PContents) === 1);
+      }
+
       // Add facets
       self.$facets = $('<div/>', {
         'class': 'h5p-facet-wrapper',
@@ -246,13 +262,17 @@ var H5PDataView = (function ($) {
         appendTo: self.$facets,
       })
     };
-
     /**
      * Callback for removing filter.
      *
      * @private
      */
     var remove = function () {
+      // Uncheck toggler for others' H5P contents
+      if ( self.$othersContentToggler && self.facets.hasOwnProperty( self.columnIdAuthor ) ) {
+        self.$othersContentToggler.prop('checked', false );
+      }
+
       self.facets[col].$tag.remove();
       delete self.facets[col];
       self.loadData();
@@ -372,6 +392,51 @@ var H5PDataView = (function ($) {
         }
       }
     }).appendTo(self.$container);
+  };
+
+  /**
+   * Add toggle for others' H5P content.
+   * @param {boolean} [checked=false] Initial check setting.
+   */
+  H5PDataView.prototype.addOthersContentToggler = function (checked) {
+    var self = this;
+
+    checked = (typeof checked === 'undefined') ? false : checked;
+
+    // Checkbox
+    this.$othersContentToggler = $('<input/>', {
+      type: 'checkbox',
+      'class': 'h5p-others-contents-toggler',
+      'id': 'h5p-others-contents-toggler',
+      'checked': checked,
+      'click': function () {
+        if ( this.checked ) {
+          // Add filter on current user
+          self.filterByFacet( self.columnIdAuthor, H5PIntegration.user.id, H5PIntegration.user.name );
+        }
+        else {
+          // Remove facet indicator and reload full data view
+          if ( self.facets.hasOwnProperty( self.columnIdAuthor ) && self.facets[self.columnIdAuthor].$tag ) {
+            self.facets[self.columnIdAuthor].$tag.remove();
+          }
+          delete self.facets[self.columnIdAuthor];
+          self.loadData();
+        }
+      }
+    });
+
+    // Label
+    var $label = $('<label>', {
+      'class': 'h5p-others-contents-toggler-label',
+      'text': this.l10n.showOwnContentOnly,
+      'for': 'h5p-others-contents-toggler'
+    });
+
+    $('<div>', {
+      'class': 'h5p-others-contents-toggler-wrapper'
+    }).append(this.$othersContentToggler)
+      .append($label)
+      .appendTo(this.$container);
   };
 
   return H5PDataView;

--- a/styles/h5p-admin.css
+++ b/styles/h5p-admin.css
@@ -266,6 +266,11 @@ button.h5p-admin.disabled:hover {
   display: none;
 }
 
+.h5p-data-view .h5p-others-contents-toggler-wrapper {
+  float: right;
+  margin-right: 0.5em;
+}
+
 .h5p-data-view th[role="button"] {
   cursor: pointer;
 }

--- a/styles/h5p-admin.css
+++ b/styles/h5p-admin.css
@@ -268,6 +268,15 @@ button.h5p-admin.disabled:hover {
 
 .h5p-data-view .h5p-others-contents-toggler-wrapper {
   float: right;
+  line-height: 2;
+  margin-right: 0.5em;
+}
+
+.h5p-data-view .h5p-others-contents-toggler-label {
+  font-size: 14px;
+}
+
+.h5p-data-view .h5p-others-contents-toggler {
   margin-right: 0.5em;
 }
 


### PR DESCRIPTION
@icc as discussed

If merged in, this pull request will add support for a toggle checkbox in the data view. It will allow to toggle between showing all contents and only the contents of the current user.

This pull request is accompanied by a pull request for the H5P-WordPress plugin: https://github.com/h5p/h5p-wordpress-plugin/pull/98

## Background
If you're using the H5P plugin on WordPress with multiple authors, it can become hard to find your own content. If there's no content of the current user on the first page, the current user cannot filter by setting a facet and she/he cannot filter for his/her name because the search field only filters on the content title.

## Implementation
Will try to retrieve user.id, user.name and user.canToggleViewOthersH5PContents from H5PIntegration. If set, allows to show/hide contents of other users using a checkbox that
uses the user parameters to set a facet on the author column.

user.canToggleViewOthersH5PContents is a trinary variable (0 = cannot toggle (don't show); 1 = can toggle, filter on current user's content by default; 2 = can toggle, show all content by default)