### PR TITLE
PHP 7.4 fix, don't use curly braces for array/string offset

### DIFF
--- a/h5p-development.class.php
+++ b/h5p-development.class.php
@@ -67,7 +67,7 @@ class H5PDevelopment {
     $contents = scandir($path);
 
     for ($i = 0, $s = count($contents); $i < $s; $i++) {
-      if ($contents[$i]{0} === '.') {
+      if ($contents[$i][0] === '.') {
         continue; // Skip hidden stuff.
       }
 

--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -2744,7 +2744,7 @@ class H5PCore {
     foreach ($arr as $key => $val) {
       $next = -1;
       while (($next = strpos($key, '_', $next + 1)) !== FALSE) {
-        $key = substr_replace($key, strtoupper($key{$next + 1}), $next, 2);
+        $key = substr_replace($key, strtoupper($key[$next + 1]), $next, 2);
       }
 
       $newArr[$key] = $val;


### PR DESCRIPTION
The array and string offset access syntax using curly braces is deprecated.
Use $str[$idx] instead of $str{$idx}.
RFC: https://wiki.php.net/rfc/deprecate_curly_braces_array_access