### PR TITLE
Fix development file path to semantics.json.

### DIFF
--- a/h5p-development.class.php
+++ b/h5p-development.class.php
@@ -153,7 +153,7 @@ class H5PDevelopment {
     if (isset($this->libraries[$library]) === FALSE) {
       return NULL;
     }
-    return $this->getFileContents($this->filesPath . $this->libraries[$library]['path'] . '/semantics.json');
+    return $this->getFileContents($this->filesPath . '/' . $this->libraries[$library]['path'] . '/semantics.json');
   }
 
   /**


### PR DESCRIPTION
I found that the development path to the `sematics.json` file was missing a `/` while working on [this issue](https://www.drupal.org/project/h5p/issues/3098548).