### PR TITLE
Allow the dependency path to be overridden by child classes

### DIFF
--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -2432,7 +2432,7 @@ class H5PCore {
     // Using content dependencies
     foreach ($dependencies as $dependency) {
       if (isset($dependency['path']) === FALSE) {
-        $dependency['path'] = 'libraries/' . H5PCore::libraryToString($dependency, TRUE);
+        $dependency['path'] = $this->getDependencyPath($dependency);
         $dependency['preloadedJs'] = explode(',', $dependency['preloadedJs']);
         $dependency['preloadedCss'] = explode(',', $dependency['preloadedCss']);
       }
@@ -2450,6 +2450,16 @@ class H5PCore {
     }
 
     return $files;
+  }
+
+  /**
+   * Get the path to the dependency.
+   *
+   * @param array $dependency
+   * @return string
+   */
+  protected function getDependencyPath(array $dependency) {
+    return 'libraries/' . H5PCore::libraryToString($dependency, TRUE);
   }
 
   private static function getDependenciesHash(&$dependencies) {


### PR DESCRIPTION
This allows an implementor to choose how the library is served.

This is a replacement for #68 which was reverted recently and which is a requirement for Moodle.