### PR TITLE
Change lint check to report fails correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ jobs:
 
 script:
   # Run a php lint across all PHP files.
-  - find . -name '*\.php' -exec php -l {} \;
+  - find . -type f -name '*\.php' -print0 | xargs -0 -n1 php -l

--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -2458,7 +2458,7 @@ class H5PCore {
    * @param array $dependency
    * @return string
    */
-  protected function getDependencyPath(array $dependency): string {
+  protected function getDependencyPath(array $dependency) {
     return 'libraries/' . H5PCore::libraryToString($dependency, TRUE);
   }
 


### PR DESCRIPTION
The `find` does not return the exit code from the execed process.
Instead we use `xargs` to execute the php lint which returns a non-zero exit code if any child process failed.