### PR TITLE
Add gltf to list of allowed file extensions

### DIFF
--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -2021,7 +2021,7 @@ class H5PCore {
     'js/h5p-utils.js',
   );
 
-  public static $defaultContentWhitelist = 'json png jpg jpeg gif bmp tif tiff svg eot ttf woff woff2 otf webm mp4 ogg mp3 m4a wav txt pdf rtf doc docx xls xlsx ppt pptx odt ods odp xml csv diff patch swf md textile vtt webvtt';
+  public static $defaultContentWhitelist = 'json png jpg jpeg gif bmp tif tiff svg eot ttf woff woff2 otf webm mp4 ogg mp3 m4a wav txt pdf rtf doc docx xls xlsx ppt pptx odt ods odp xml csv diff patch swf md textile vtt webvtt gltf';
   public static $defaultLibraryWhitelistExtras = 'js css';
 
   public $librariesJsonData, $contentJsonData, $mainJsonData, $h5pF, $fs, $h5pD, $disableFileCheck;

--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -2021,7 +2021,7 @@ class H5PCore {
     'js/h5p-utils.js',
   );
 
-  public static $defaultContentWhitelist = 'json png jpg jpeg gif bmp tif tiff svg eot ttf woff woff2 otf webm mp4 ogg mp3 m4a wav txt pdf rtf doc docx xls xlsx ppt pptx odt ods odp xml csv diff patch swf md textile vtt webvtt gltf';
+  public static $defaultContentWhitelist = 'json png jpg jpeg gif bmp tif tiff svg eot ttf woff woff2 otf webm mp4 ogg mp3 m4a wav txt pdf rtf doc docx xls xlsx ppt pptx odt ods odp xml csv diff patch swf md textile vtt webvtt gltf glb';
   public static $defaultLibraryWhitelistExtras = 'js css';
 
   public $librariesJsonData, $contentJsonData, $mainJsonData, $h5pF, $fs, $h5pD, $disableFileCheck;


### PR DESCRIPTION
It would be great if glTF was included in the default list of whitelisted file extensions so (future) H5P content types may use it to make use of 3D models.

The glTF (Graphics Library Transmission Format) is a common and royalty free JSON based file format for 3D models used in open-source WebGL engines including Three.js (already used within H5P content types) and A-Frame. It's used in a variety of 3D modeling tools, e.g. Blender, Vectary, Autodesk 3ds Max, Autodesk Maya. Please cmp. https://github.com/KhronosGroup/glTF
