### PR TITLE
Fix step validation of number field

### DIFF
--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -3754,7 +3754,7 @@ class H5PContentValidator {
     // Check if number is within allowed bounds even if step value is set.
     if (isset($semantics->step)) {
       $testNumber = $number - (isset($semantics->min) ? $semantics->min : 0);
-      $rest = $testNumber % $semantics->step;
+      $rest = fmod($testNumber, $semantics->step);
       if ($rest !== 0) {
         $number -= $rest;
       }


### PR DESCRIPTION
Will allow validation of number fields with step that's not an integer. HTML5 fields allow steps to be float numbers.

Required for https://github.com/h5p/h5p-editor-php-library/pull/115