### PR TITLE
Do not remove crossOrigin property.

### DIFF
--- a/js/h5p.js
+++ b/js/h5p.js
@@ -733,7 +733,7 @@ H5P.fullScreen = function ($element, instance, exitCallback, body, forceSemiFull
     }
     else {
       // In case this element has been used before.
-      element.removeAttribute('crossorigin');
+      element.crossOrigin = "anonymous";
     }
 
     element.src = H5P.getPath(path, contentId);


### PR DESCRIPTION
Hi @icc 

We're having an issue displaying some h5p avtivities with [Objectfs Pre-Signed feature enabled ](https://github.com/catalyst/moodle-tool_objectfs#pre-signed-urls-settings) (this feature allows you to grant temporary access and lets users to download resourses directly from S3 bucket).

For example, https://h5p.org/virtual-tour-360 looks like:
![image](https://user-images.githubusercontent.com/22066290/87620195-4a44cf00-c761-11ea-891c-b7abd97be164.png)

Error from console:

```
THREE.WebGLState: DOMException: Failed to execute 'texImage2D' on 'WebGLRenderingContext': The image element contains cross-origin data, and may not be loaded.
    at Object.texImage2D (https://sandbox.local/pluginfile.php/1/mod_hvp/cachedassets/6fbeb1fa452bb8721948e8ba1897f3403dc4e01c.js:2228:505)
    at z (https://sandbox.local/pluginfile.php/1/mod_hvp/cachedassets/6fbeb1fa452bb8721948e8ba1897f3403dc4e01c.js:2241:146)
    at Ug.u [as setTexture2D] (https://sandbox.local/pluginfile.php/1/mod_hvp/cachedassets/6fbeb1fa452bb8721948e8ba1897f3403dc4e01c.js:2235:121)
    at de.setTexture2D (https://sandbox.local/pluginfile.php/1/mod_hvp/cachedassets/6fbeb1fa452bb8721948e8ba1897f3403dc4e01c.js:2315:325)
    at Cg.mg [as setValue] (https://sandbox.local/pluginfile.php/1/mod_hvp/cachedassets/6fbeb1fa452bb8721948e8ba1897f3403dc4e01c.js:2164:87)
    at Function.eb.upload (https://sandbox.local/pluginfile.php/1/mod_hvp/cachedassets/6fbeb1fa452bb8721948e8ba1897f3403dc4e01c.js:2741:135)
    at t (https://sandbox.local/pluginfile.php/1/mod_hvp/cachedassets/6fbeb1fa452bb8721948e8ba1897f3403dc4e01c.js:2292:226)
    at de.renderBufferDirect (https://sandbox.local/pluginfile.php/1/mod_hvp/cachedassets/6fbeb1fa452bb8721948e8ba1897f3403dc4e01c.js:2307:576)
    at q (https://sandbox.local/pluginfile.php/1/mod_hvp/cachedassets/6fbeb1fa452bb8721948e8ba1897f3403dc4e01c.js:2277:439)
    at m (https://sandbox.local/pluginfile.php/1/mod_hvp/cachedassets/6fbeb1fa452bb8721948e8ba1897f3403dc4e01c.js:2277:133)
```

We could fix the issue by setting `element.crossOrigin` to a random value (empty string or eg `anonymous`). I've found this method was introduced by you as part of [this commit](https://github.com/h5p/h5p-php-library/commit/fec8953ba888e04769c33bcd7225d4e3de9a8bea).

Is there any objections to get this pr merged? Or maybe you have a better solution.

Thanks,
Mikhail