### PR TITLE
HFP-3065 Allow to delete library if circular dependency

### DIFF
--- a/js/h5p-library-list.js
+++ b/js/h5p-library-list.js
@@ -60,6 +60,9 @@ var H5PLibraryList = H5PLibraryList || {};
       H5PLibraryList.addRestricted($('.h5p-admin-restricted', $libraryRow), library.restrictedUrl, library.restricted);
 
       var hasContent = !(library.numContent === '' || library.numContent === 0);
+      const hasContentDependencies = (library.numContentDependencies !== '' && library.numContentDependencies !== 0);
+      const hasLibraryDependencies = (library.numLibraryDependencies !== '' && library.numLibraryDependencies !== 0);
+
       if (library.upgradeUrl === null) {
         $('.h5p-admin-upgrade-library', $libraryRow).remove();
       }
@@ -78,12 +81,13 @@ var H5PLibraryList = H5PLibraryList || {};
       });
 
       var $deleteButton = $('.h5p-admin-delete-library', $libraryRow);
-      if (libraries.notCached !== undefined ||
-          hasContent ||
-          (library.numContentDependencies !== '' &&
-           library.numContentDependencies !== 0) ||
-          (library.numLibraryDependencies !== '' &&
-           library.numLibraryDependencies !== 0)) {
+      if (
+        libraries.notCached !== undefined ||
+        hasContent ||
+        hasContentDependencies ||
+        hasLibraryDependencies &&
+        !(library.hasCircularEditorDepencendy && library.numLibraryDependencies === 1)
+      ) {
         // Disabled delete if content.
         $deleteButton.attr('disabled', true);
       }


### PR DESCRIPTION
A long time ago in a galaxy far far away, the `H5PLibraryList` class was created to allow H5P library management - including deletion of libraries. Libraries cannot be deleted, of course, if some content or library still depends on it.

Unfortunately, it is possible that a content library is used for the view and the editor alike, e.g. Course Presentation. _H5P.CoursePresentation_ has an "editor" dependency to _H5PEditor.CoursePresentation_, and _H5PEditor.CoursePresentation_ has a "preloaded" dependency to _H5P.CoursePresentation_. This direct circular dependency prevents both libraries from being deleted (without manually modifying the relevant entries in the `h5p_libraries_libraries` database table.

When merged in, the `H5PLibraryList` class will now check the library data for a `hasCircularEditorDepencendy` flag that needs to be set in the integration. If set and the respective editor library is the only library that requires the library at stake, then it is safe to delete it and the delete button will not be disabled.

Setting the `hasCircularEditorDepencendy` flag if appropriate and allowing the library to be deleted needs implementation in the integrations. There's a pull request for the WordPress plugin as a reference at https://github.com/h5p/h5p-wordpress-plugin/pull/125. It could easily be ported to other integrations if this pull request is accepted.