### PR TITLE
H5P module is locking session while saving large content

### DIFF
--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -1927,6 +1927,11 @@ Class H5PExport {
       }
     }
 
+    // Close session before finishing zip file, which might take
+    // substantial time to allow other pages to use session without
+    // waiting on the file operation to finish.
+    \core\session\manager::write_close();
+
     // Close zip and remove tmp dir
     $zip->close();
     H5PCore::deleteFileTree($tmpPath);


### PR DESCRIPTION
When a user is saving large H5P content (~2Gb) in Moodle it takes about 60 seconds to process changes. However, due to the session locking it is not possible to open another Moodle page in a new browser tab. It ends up with the error "Unable to obtain session lock".

Steps to reproduce the issue in Moodle:

1. Create a new course or use an existing course in Moodle.
2. In the course main page add a new activity.
3. Choose H5P Interactive Content.
4. Provide some description in Description section.
5. Inside the editor section choose Upload and upload a large H5P package.
6. Click "Save and Return to course".
7. Find the activity that has been created, click Edit -> Edit Settings.
8. Do not change anything, click "Save and Display". The page will be processing changes for ~90 sec. Go to next step without waiting for it to finish.
9. Try to open a course page in a new browser tab. It will not open, but start waiting and give the error "Unable to obtain session lock".

Profiling shows that 95% of time is spent inside h5p.classes.php: H5PExport > createExportFile > $zip->Close() call.
The solution for the session locking would be to write_close() the session before finishing zip file. It will allow other pages to use session without waiting on the file operation to finish.

The following scenarios were tested:

1. Save page with H5P content and try opening another page. With the patched version the new page opened instantly instead of waiting.
2. Open and save H5P content in two parallel uploads. This worked well too, both pages saved correctly and no unnecessary waiting happened.
3. Save page with H5P content and try opening the same page in a new tab. In this case the new page waited until the H5P content is saved. It seems to be the case when waiting cannot be avoided since it is trying to access the very content which is being saved.

After adding the fix all tests were conducted with Moodle logging enabled, which did not show any issues. Apache and php error logs were checked for errors as well. Everything worked as it should.