### PR TITLE
Trigger set user data more often to ensure state transmission

### DIFF
--- a/js/h5p.js
+++ b/js/h5p.js
@@ -2865,11 +2865,11 @@ H5P.createTitle = function (rawTitle, maxLength) {
       // iPad does not support beforeunload, therefore using unload
       H5P.$window.one('beforeunload unload', function () {
         // Only want to do this once
-        H5P.$window.off('pagehide beforeunload unload');
+        H5P.$window.off('pagehide visibilitychange beforeunload unload');
         storeCurrentState();
       });
       // pagehide is used on iPad when tabs are switched
-      H5P.$window.on('pagehide', storeCurrentState);
+      H5P.$window.on('pagehide visibilitychange', storeCurrentState);
     }
   });
 

--- a/js/h5p.js
+++ b/js/h5p.js
@@ -243,7 +243,7 @@ H5P.init = function (target) {
       // xAPI events will schedule a save in three seconds.
       H5P.on(instance, 'xAPI', function (event) {
         var verb = event.getVerb();
-        if (verb === 'completed' || verb === 'progressed') {
+        if (verb === 'completed' || verb === 'progressed' || verb === 'answered') {
           clearTimeout(saveTimer);
           saveTimer = setTimeout(save, 3000);
         }


### PR DESCRIPTION
Saving the content state is unreliable if the user closes the tab, see https://github.com/h5p/h5p-php-library/issues/106 for details.

When merged in, the setUserData function will also be triggered on the `visibilitychange` event and on the xAPI `answered` event.

Those new triggers would only cause an AJAX request to the server if the state actually changed, because H5P checks, so these two additions should not have a performance impact server-side.