### PR TITLE
HFP-3465 Fix line breaks breaking metadata field validation

### DIFF
--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -704,15 +704,15 @@ class H5PValidator {
     'source' => '/^(http[s]?:\/\/.+)$/',
     'license' => '/^(CC BY|CC BY-SA|CC BY-ND|CC BY-NC|CC BY-NC-SA|CC BY-NC-ND|CC0 1\.0|GNU GPL|PD|ODC PDDL|CC PDM|U|C)$/',
     'licenseVersion' => '/^(1\.0|2\.0|2\.5|3\.0|4\.0)$/',
-    'licenseExtras' => '/^.{1,5000}$/',
+    'licenseExtras' => '/^(.|\n|\r){1,5000}$/',
     'yearsFrom' => '/^([0-9]{1,4})$/',
     'yearsTo' => '/^([0-9]{1,4})$/',
     'changes' => array(
       'date' => '/^[0-9]{2}-[0-9]{2}-[0-9]{2} [0-9]{1,2}:[0-9]{2}:[0-9]{2}$/',
       'author' => '/^.{1,255}$/',
-      'log' => '/^.{1,5000}$/'
+      'log' => '/^(.|\n|\r){1,5000}$/'
     ),
-    'authorComments' => '/^.{1,5000}$/',
+    'authorComments' => '/^(.|\n|\r){1,5000}$/',
     'w' => '/^[0-9]{1,4}$/',
     'h' => '/^[0-9]{1,4}$/',
     // deprecated

--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -704,15 +704,15 @@ class H5PValidator {
     'source' => '/^(http[s]?:\/\/.+)$/',
     'license' => '/^(CC BY|CC BY-SA|CC BY-ND|CC BY-NC|CC BY-NC-SA|CC BY-NC-ND|CC0 1\.0|GNU GPL|PD|ODC PDDL|CC PDM|U|C)$/',
     'licenseVersion' => '/^(1\.0|2\.0|2\.5|3\.0|4\.0)$/',
-    'licenseExtras' => '/^(.|\n|\r){1,5000}$/',
+    'licenseExtras' => '/^.{1,5000}$/s',
     'yearsFrom' => '/^([0-9]{1,4})$/',
     'yearsTo' => '/^([0-9]{1,4})$/',
     'changes' => array(
       'date' => '/^[0-9]{2}-[0-9]{2}-[0-9]{2} [0-9]{1,2}:[0-9]{2}:[0-9]{2}$/',
       'author' => '/^.{1,255}$/',
-      'log' => '/^(.|\n|\r){1,5000}$/'
+      'log' => '/^.{1,5000}$/s'
     ),
-    'authorComments' => '/^(.|\n|\r){1,5000}$/',
+    'authorComments' => '/^.{1,5000}$/s',
     'w' => '/^[0-9]{1,4}$/',
     'h' => '/^[0-9]{1,4}$/',
     // deprecated


### PR DESCRIPTION
Currently the metadata fields for `licenseExtras`, `changes.log` and `authorComments` do not consider line breaks to be a valid character for the input value, yet the editor allows to enter line breaks and doesn't filter them out. This doesn't seem to cause trouble when the content isn't shared, but once you download it and try to upload it on any H5P instance (even the same), you'll get notified that those fields are not valid.

When merged in, the metadata fields for `licenseExtras`, `changes.log` and `authorComments` will not consider line breaks to be invalid characters anymore.