### PR TITLE
[BUG] - Fix double slash

### DIFF
--- a/h5p-default-storage.class.php
+++ b/h5p-default-storage.class.php
@@ -215,7 +215,7 @@ class H5PDefaultStorage implements \H5PFileStorage {
                   if (preg_match("/^(data:|([a-z0-9]+:)?\/)/i", $matches[1]) === 1) {
                     return $matches[0]; // Not relative, skip
                   }
-                  if (strpos(url, "/") == 0) {
+                  if (strpos($cssRelPath, "/") == 0) {
                     // To avoid duplicate double slash
                     $cssRelPath = substr($cssRelPath, 1);
                   }

--- a/h5p-default-storage.class.php
+++ b/h5p-default-storage.class.php
@@ -215,6 +215,10 @@ class H5PDefaultStorage implements \H5PFileStorage {
                   if (preg_match("/^(data:|([a-z0-9]+:)?\/)/i", $matches[1]) === 1) {
                     return $matches[0]; // Not relative, skip
                   }
+                  if (strpos(url, "/") == 0) {
+                    // To avoid duplicate double slash
+                    $cssRelPath = substr($cssRelPath, 1);
+                  }
                   return 'url("../' . $cssRelPath . $matches[1] . '")';
               },
               $assetContent) . "\n";


### PR DESCRIPTION
Once Cache Assets copying the CSS file and handles the CSS import, it uses a double slash for inline CSS imports.

In most of the cases is not an issue at all, cause most of the servers know how to handle those, but once you deliver you assets files form S3 it's become a major problem