### PR TITLE
Fix warning when minifying CSS

### DIFF
--- a/styles/h5p.css
+++ b/styles/h5p.css
@@ -179,7 +179,7 @@ div.h5p-fullscreen {
   /* Hack for IOS landscape / portrait */
   width: 10px;
   min-width: 100%;
-  *width: 100%;
+  width: 100%;
   /* End of hack */
   height: 100%;
   z-index: 10;


### PR DESCRIPTION
I'm minifying `h5p.css` in a dependent project with esbuild and am getting a warning as follows:

```
rendering chunks (1)...warnings when minifying css:
 > <stdin>:168:2: warning: Expected identifier but found "*"
    168 │   *width: 100%;
```

This is no valid CSS. But since there is a comment about a "hack" nearby, I investigated a bit more: Git blame leads me to this PR: #36. The upstream bug mentioned in that PR at https://bugs.webkit.org/show_bug.cgi?id=155198 talks about using `min-width` as the hack. So it should be safe to fix the warning.