### PR TITLE
Add contentId to initialized event

### DIFF
--- a/js/h5p.js
+++ b/js/h5p.js
@@ -365,7 +365,7 @@ H5P.init = function (target) {
     });
 
     if (H5P.externalDispatcher) {
-      H5P.externalDispatcher.trigger('initialized');
+      H5P.externalDispatcher.trigger('initialized', { contentId: contentId });
     }
   });
 


### PR DESCRIPTION
When merged in, the 'initialized' event that is dispatched to the outside world will contain the contentId as payload, allowing H5P integrations and other extensions to know what H5P content was initialized in case there are multiple contents launched.