### PR TITLE
Mixed version dependency conflict

### DIFF
--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -2641,7 +2641,7 @@ class H5PCore {
       }
 
       foreach ($library[$property] as $dependency) {
-        $dependencyKey = $type . '-' . $dependency['machineName'];
+        $dependencyKey = $type . '-' . $dependency['machineName'] . '-' . $library['majorVersion'] . '-' . $library['minorVersion'];
         if (isset($dependencies[$dependencyKey]) === TRUE) {
           continue; // Skip, already have this.
         }
@@ -4183,7 +4183,7 @@ class H5PContentValidator {
    * Add Addon library.
    */
   public function addon($library) {
-    $depKey = 'preloaded-' . $library['machineName'];
+    $depKey = 'preloaded-' . $library['machineName']  . '-' . $library['majorVersion'] . '-' . $library['minorVersion'];
     $this->dependencies[$depKey] = array(
       'library' => $library,
       'type' => 'preloaded'
@@ -4753,7 +4753,7 @@ class H5PContentValidator {
     }
 
     // Find all dependencies for this library
-    $depKey = 'preloaded-' . $library['machineName'];
+    $depKey = 'preloaded-' . $library['machineName'] . '-' . $library['majorVersion'] . '-' . $library['minorVersion'];
     if (!isset($this->dependencies[$depKey])) {
       $this->dependencies[$depKey] = array(
         'library' => $library,


### PR DESCRIPTION
When an H5P has dependencies on multiple versions of the same library, the export will only generate with the first dependency it comes across, rather than all versions.

This is because the keys used to identify which dependencies are needed only relies on machine name, but not version number.