### PR TITLE
HFP-3649 Fix confirmation dialog button positioning

### DIFF
--- a/styles/h5p-confirmation-dialog.css
+++ b/styles/h5p-confirmation-dialog.css
@@ -94,6 +94,7 @@ button.h5p-confirmation-dialog-exit {
   color: #fff;
   cursor: pointer;
   text-decoration: none;
+  padding: 1px 6px; /* Safari's user agent button style adds way too much padding */
 }
 
 button.h5p-confirmation-dialog-exit:focus,


### PR DESCRIPTION
Safari's user agent style for `button` elements adds a horizontal padding of `1em` which usually translates to `16px`. That puts the confirmation dialogs exit button out of place looking very weird.

When merged in, will apply a padding value of `1px 6px` which is Blink's user agent style for padding of `button` elements and seems to have been the targeted platform to have checked against - thus looking fine (even though the while confirmation dialog visuals might need some overhaul :-)).