### PR TITLE
HFP-3650 Fix semi-fullscreen impact by integration CSS

### DIFF
--- a/styles/h5p.css
+++ b/styles/h5p.css
@@ -169,6 +169,8 @@ div.h5p-fullscreen {
   right: 0;
   bottom: 0;
   z-index: 100001;
+  margin: 0;
+  padding: 0;
 }
 .h5p-iframe-wrapper.h5p-semi-fullscreen .buttons {
   position: absolute;

--- a/styles/h5p.css
+++ b/styles/h5p.css
@@ -76,6 +76,7 @@ html.h5p-iframe .h5p-semi-fullscreen .h5p-content {
   background-color: #000;
 }
 body.h5p-semi-fullscreen {
+  background-color: #fff;
   position: fixed;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
When H5P core sends content into `semi-fullscreen` mode, the stylesheet of the platform (e.g. WordPress) may impact the iframe style and prevent a fullscreen look.

When merged in, the iframe with `semi-fullscreen` selector will get `margin` and `padding` set to `0` in order to overrule the styling set by the H5P integration. Also, the background color will explicitly set to #fff in order to overrule the platform's background color setting in semi-fullscreen mode.