### PR TITLE
fix: removed unused code that leads to errors

### DIFF
--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -4026,20 +4026,6 @@ class H5PContentValidator {
         }
       }
     }
-    if (!(isset($semantics->optional) && $semantics->optional)) {
-      if ($group === NULL) {
-        // Error no value. Errors aren't printed...
-        return;
-      }
-      foreach ($semantics->fields as $field) {
-        if (!(isset($field->optional) && $field->optional)) {
-          // Check if field is in group.
-          if (! property_exists($group, $field->name)) {
-            //$this->h5pF->setErrorMessage($this->h5pF->t('No value given for mandatory field ' . $field->name));
-          }
-        }
-      }
-    }
   }
 
   /**


### PR DESCRIPTION
Error was:

```
property_exists(): Argument #1 ($object_or_class) must be of type object|string, array given
```

while playing a h5p content. 