### PR TITLE
Fix deprecation warning on empty str_replace() parameter

### DIFF
--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -1815,7 +1815,10 @@ Class H5PExport {
    * @return string
    */
   private static function revertH5PEditorTextEscape($value) {
-    return str_replace('&lt;', '<', str_replace('&gt;', '>', str_replace('&#039;', "'", str_replace('&quot;', '"', $value))));
+    if (empty($value)) {
+      return '';
+    }
+    return str_replace(['&quot;', '&#039;', '&gt;', '&lt;'], ['"', "'", '>', '<'], $value);
   }
 
   /**


### PR DESCRIPTION
This fixes a deprecation error: 

Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /var/www/html/vendor/h5p/h5p-core/h5p.classes.php on line 1763

The error is given in Drupal on PHP 8.1 when saving a node with a H5P element.