### PR TITLE
HFP-3815 Add reduced motion mode to confirmation dialog

### DIFF
--- a/styles/h5p-confirmation-dialog.css
+++ b/styles/h5p-confirmation-dialog.css
@@ -181,3 +181,18 @@ button.h5p-confirmation-dialog-exit:hover {
     transform: rotate(359deg);
   }
 }
+
+@media (prefers-reduced-motion) {
+  .h5p-confirmation-dialog-background {
+    .h5p-confirmation-dialog-popup {
+      -webkit-transition: none;
+      transition: none;
+    }
+
+    &.hiding {
+      .h5p-confirmation-dialog-popup {
+        opacity: 0;
+      }
+    }
+  }
+}


### PR DESCRIPTION
When merged in, will not animate the Confirmation Dialog entry/exit if the user has expressed to prefer reduced motion on his/her device. See https://h5ptechnology.atlassian.net/browse/HFP-3815 for details.