### PR TITLE
[ENH] h5p.classes : prevents exception Warning: foreach() argument mu…

### DIFF
--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -2264,20 +2264,24 @@ class H5PCore {
 
     // Handle addons:
     $addons = $this->h5pF->loadAddons();
-    foreach ($addons as $addon) {
-      $add_to = json_decode($addon['addTo']);
 
-      if (isset($add_to->content->types)) {
-        foreach($add_to->content->types as $type) {
+    // Makes sure we don't loop through a null value and prevents errors
+    if ($addons) {
+      foreach ($addons as $addon) {
+        $add_to = json_decode($addon['addTo']);
 
-          if (isset($type->text->regex) &&
-              $this->textAddonMatches($params->params, $type->text->regex)) {
-            $validator->addon($addon);
+        if (isset($add_to->content->types)) {
+          foreach($add_to->content->types as $type) {
+            if (isset($type->text->regex) &&
+                $this->textAddonMatches($params->params, $type->text->regex)) {
+              $validator->addon($addon);
 
-            // An addon shall only be added once
-            break;
+              // An addon shall only be added once
+              break;
+            }
           }
         }
+
       }
     }
 

--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -2283,6 +2283,8 @@ class H5PCore {
         }
 
       }
+    } else {
+      return NULL;
     }
 
     $params = json_encode($params->params);


### PR DESCRIPTION
This is to mostly prevent the error `ErrorException
Warning: foreach() argument must be of type array|object, null given` when trying to loop through a null `$addons` value, in case we don’t get any when handling addons.