### PR TITLE
Delete button for libraries list

### DIFF
--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -350,6 +350,14 @@ interface H5PFrameworkInterface {
    */
   public function getLibraryUsage($libraryId, $skipContent = FALSE);
 
+    /**
+     * Get the names of dependencies to other libraries
+     *
+     * @param int $id
+     * @return array The array contains the names of the dependet libraries
+     */
+    public function getLibraryUsageNames($id);
+
   /**
    * Loads a library
    *

--- a/js/h5p-library-list.js
+++ b/js/h5p-library-list.js
@@ -81,9 +81,7 @@ var H5PLibraryList = H5PLibraryList || {};
       if (libraries.notCached !== undefined ||
           hasContent ||
           (library.numContentDependencies !== '' &&
-           library.numContentDependencies !== 0) ||
-          (library.numLibraryDependencies !== '' &&
-           library.numLibraryDependencies !== 0)) {
+              library.numContentDependencies !== 0)) {
         // Disabled delete if content.
         $deleteButton.attr('disabled', true);
       }


### PR DESCRIPTION
The delete button for libraries is now only deactivated if the library is in use and not if there is a dependency. Because of the circular dependencies of the libraries, they can otherwise never be deleted.
In addition, a new method call has been added to the interface for the framework.