### PR TITLE
Replace call to str_contains() to ensure PHP 7.4 compatibility

### DIFF
--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -5039,7 +5039,7 @@ class H5PContentValidator {
               // Allow certain styles
 
               // Prevent font family from getting split wrong because of the ; in &quot;
-              if (str_contains($match[1], 'font-family')) {
+              if (strpos($match[1], 'font-family') !== false) {
                 $match[1] = str_replace('&quot;', "'", $match[1]);
               }
 


### PR DESCRIPTION
On the Moodle plugin repository, mod_hvp claims to support Moodle 4.1, which will remain security supported by Moodle until December 2025. Moodle 4.1 supports PHP 7.4, and therefore to maintain compatibility, mod_hvp must support PHP 7.4. In the latest release, a call to str_contains() was added to h5p.classes.php, which is not compatible with PHP 7.4. This has resulted in errors on Moodle sites, including one of our clients as well as this issue I found from another user [here](https://h5p.org/node/1505631).

This pull request is to replace the function call with a compatible equivalent.