### PR TITLE
Fix resizing issue when flickering

### DIFF
--- a/js/h5p.js
+++ b/js/h5p.js
@@ -270,14 +270,17 @@ H5P.init = function (target) {
           //        @see https://github.com/h5p/h5p-moodle-plugin/issues/237
           iframe.getBoundingClientRect();
 
-          // Reset iframe height, in case content has shrinked.
-          iframe.style.height = '1px';
 
-          // Resize iframe so all content is visible.
-          iframe.style.height = (iframe.contentDocument.body.scrollHeight) + 'px';
+          var currentHeight = parseInt(iframe.style.height, 10) || 0;
+          var newHeight = iframe.contentDocument.body.scrollHeight;
 
-          // Free parent
-          iframe.parentElement.style.height = parentHeight;
+          var thresholdPercent = 0.01;
+          // Only resize if the height difference is significant
+          if (Math.abs(currentHeight - newHeight) >= (currentHeight * thresholdPercent)) {
+            iframe.style.height = '1px'; // Reset height
+            iframe.style.height = newHeight + 'px'; // Set new height
+            iframe.parentElement.style.height = parentHeight; // Restore parent height
+          }
         };
 
         H5P.on(instance, 'resize', function () {


### PR DESCRIPTION
This issue was first noticed in https://tracker.moodle.org/browse/MDL-84032.

The root of the problem seems that when content is also responsive (font for example) the resizing in some case creates an infinite loop that leads to constant resizing of the activity leading to a flickering effect. 
By using a threshold under which the iframe is not resized, we avoid the flickering.