### PR TITLE
AU-7270 Ensure iframe inside h5p iframe sends referer on iPhone

### DIFF
--- a/js/h5p.js
+++ b/js/h5p.js
@@ -380,9 +380,7 @@ H5P.init = function (target) {
       ? contentData.metadata.defaultLanguage : 'en';
 
     const writeDocument = function () {
-      iframe.contentDocument.open();
-      iframe.contentDocument.write('<!doctype html><html class="h5p-iframe" lang="' + contentLanguage + '"><head>' + H5P.getHeadTags(contentId) + '</head><body><div class="h5p-content" data-content-id="' + contentId + '"/></body></html>');
-      iframe.contentDocument.close();
+      iframe.srcdoc = '<!doctype html><html class="h5p-iframe" lang="' + contentLanguage + '"><head>' + H5P.getHeadTags(contentId) + '</head><body><div class="h5p-content" data-content-id="' + contentId + '"/></body></html>';
     };
 
     $iframe.addClass('h5p-initialized')


### PR DESCRIPTION
This should solve the issue where protected vimeo videos can't be used as a src for Interactive Video on iPhone.