### PR TITLE
VA-936 Make confirmation dialog buttons use theme style

### DIFF
--- a/js/h5p-confirmation-dialog.js
+++ b/js/h5p-confirmation-dialog.js
@@ -143,14 +143,18 @@ H5P.ConfirmationDialog = (function (EventDispatcher) {
     // Cancel button
     if (!options.hideCancel) {
       var cancelButton = document.createElement('button');
-      cancelButton.classList.add('h5p-core-cancel-button');
-      cancelButton.textContent = options.cancelText;
+      if (!options.theme) {
+        cancelButton.classList.add('h5p-core-cancel-button');
+      }
+      else {
+        cancelButton.classList.add('h5p-theme-secondary-cta');
+        cancelButton.classList.add('h5p-theme-cancel');
+      }
+      const cancelText = document.createElement('span');
+      cancelText.textContent = options.cancelText;
+      cancelButton.appendChild(cancelText);
       cancelButton.addEventListener('click', dialogCanceled);
       buttons.appendChild(cancelButton);
-      
-      if (options.theme) {
-        cancelButton.classList.add('h5p-theme-secondary-cta');
-      }
     }
     else {
       // Center remaining buttons
@@ -159,7 +163,9 @@ H5P.ConfirmationDialog = (function (EventDispatcher) {
 
     // Confirm button
     var confirmButton = document.createElement('button');
-    confirmButton.classList.add('h5p-core-button');
+    if (!options.theme) {
+      confirmButton.classList.add('h5p-core-button');
+    }
    // confirmButton.classList.add('h5p-confirmation-dialog-confirm-button');
     confirmButton.setAttribute('aria-label', options.confirmText);
 

--- a/styles/h5p-confirmation-dialog.css
+++ b/styles/h5p-confirmation-dialog.css
@@ -245,9 +245,23 @@ button.h5p-confirmation-dialog-exit:focus, button.h5p-confirmation-dialog-exit:h
 }
 
 .h5p-theme .h5p-confirmation-dialog-buttons {
+  container-type: inline-size;
+  container-name: h5p-confirmation-dialog-buttons;
   display: flex;
-  justify-content: end;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--h5p-theme-spacing-s);
   width: 100%;
+}
+
+.h5p-theme .h5p-confirmation-dialog-buttons button.h5p-theme-primary-cta {
+  max-width: fit-content;
+}
+
+.h5p-theme .h5p-confirmation-dialog-buttons button.h5p-theme-cancel::before {
+  content: "\e910";
+  font-family: "h5p-theme";
+  font-size: 90%;
 }
 
 .h5p-theme .h5p-confirmation-dialog-buttons .h5p-theme-secondary-cta {
@@ -264,23 +278,25 @@ button.h5p-confirmation-dialog-exit:focus, button.h5p-confirmation-dialog-exit:h
   padding-right: unset;
 }
 
-@media only screen and (max-width: 640px) {
-  .h5p-theme .h5p-confirmation-dialog-buttons {
-    flex-direction: column;
+@container (max-width: 400px) {
+  .h5p-theme .h5p-confirmation-dialog-buttons .h5p-theme-primary-cta:before {
+    margin-right: 0;
+    opacity: 1;
+    padding: 0;
+    position: unset;
+    text-indent: 0;
+    transform: translate(0, 0);
   }
 
-  .h5p-theme .h5p-confirmation-dialog-popup .h5p-core-cancel-button,
-  .h5p-theme .h5p-confirmation-dialog-popup .h5p-core-button {
-    display: block;
-    box-sizing: border-box;
-    width: 100%;
+  .h5p-theme .h5p-confirmation-dialog-buttons span {
+    display: none;
   }
+}
 
-  .h5p-theme .h5p-confirmation-dialog-popup .h5p-core-button {
-    margin-top: var(--h5p-theme-spacing-xs);
-  }
-
-  .h5p-theme .h5p-confirmation-dialog-popup .h5p-core-button::before {
-    text-indent: -2rem;
+@container (max-width: 200px) {
+  .h5p-theme .h5p-confirmation-dialog-buttons .h5p-theme-secondary-cta {
+    height: var(--h5p-theme-spacing-xl);
+    min-width: var(--h5p-theme-spacing-xl);
+    padding: 0;
   }
 }


### PR DESCRIPTION
When merged in, will make the confirmation dialog's buttons look and feel like the rest of the themed buttons.