### PR TITLE
VA-1210 Tweak visual appearance of reuse dialog

### DIFF
--- a/js/h5p.js
+++ b/js/h5p.js
@@ -1293,20 +1293,25 @@ H5P.buildMetadataCopyrights = function (metadata) {
  */
 H5P.openReuseDialog = function ($element, contentData, library, instance, contentId) {
   let html = '';
+  let buttonCount = 0;
   if (contentData.displayOptions.export) {
     html += '<button type="button" class="h5p-big-button h5p-download-button"><div class="h5p-button-title">Download as an .h5p file</div><div class="h5p-button-description">.h5p files may be uploaded to any web-site where H5P content may be created.</div></button>';
+    buttonCount += 1;
   }
   if (contentData.displayOptions.export && contentData.displayOptions.copy) {
     html += '<div class="h5p-horizontal-line-text"><span>or</span></div>';
   }
   if (contentData.displayOptions.copy) {
     html += '<button type="button" class="h5p-big-button h5p-copy-button"><div class="h5p-button-title">Copy content</div><div class="h5p-button-description">Copied content may be pasted anywhere this content type is supported on this website.</div></button>';
+    buttonCount += 1;
   }
 
   const dialog = new H5P.Dialog('reuse', H5P.t('reuseContent'), html, $element);
 
   // Selecting embed code when dialog is opened
   H5P.jQuery(dialog).on('dialog-opened', function (e, $dialog) {
+    const scrollContent = $dialog[0].querySelector('.h5p-scroll-content');
+    scrollContent.style.setProperty('--button-count', buttonCount);
     H5P.jQuery('<a href="https://h5p.org/node/442225" target="_blank">More Info</a>').click(function (e) {
       e.stopPropagation();
     }).appendTo($dialog.find('h2'));
@@ -1902,7 +1907,7 @@ H5P.MediaCopyright = function (copyright, labels, order, extraFields) {
  * @param {string} source
  * @param {number} width
  * @param {number} height
- * @param {string} alt 
+ * @param {string} alt
  *  alternative text for the thumbnail
  */
 H5P.Thumbnail = function (source, width, height, alt) {
@@ -2724,7 +2729,7 @@ H5P.createTitle = function (rawTitle, maxLength) {
         }
         return path.substr(0, prefix.length) === prefix ? path : prefix + path;
       }
-      
+
       return path; // Will automatically be looked for in tmp folder
     });
 

--- a/styles/h5p-theme.css
+++ b/styles/h5p-theme.css
@@ -14,16 +14,31 @@
 /* DIALOGS */
 .h5p-content:has(.h5p-theme) .h5p-popup-dialog {
   background-color: rgba(0, 0, 0, 0.85);
+  container-name: h5p-popup-dialog;
+  container-type: inline-size;
 }
 
 .h5p-content:has(.h5p-theme) .h5p-popup-dialog .h5p-inner {
-  min-width: 35rem;
   color: var(--h5p-theme-text-primary);
   border-radius: var(--h5p-theme-border-radius-large);
 }
 
 .h5p-content:has(.h5p-theme) .h5p-reuse-dialog .h5p-inner {
   max-width: 45rem;
+  width: fit-content;
+}
+
+.h5p-content:has(.h5p-theme) .h5p-reuse-dialog.h5p-popup-dialog.h5p-open .h5p-scroll-content {
+  border-top: 0;
+  padding-top: 4.5em;
+}
+
+.h5p-content:has(.h5p-theme) .h5p-popup-dialog.h5p-reuse-dialog .h5p-inner > h2 {
+  box-shadow: none;
+}
+
+.h5p-content:has(.h5p-theme) .h5p-reuse-dialog .h5p-inner > h2 > a {
+  color: var(--h5p-theme-main-cta-base);
 }
 
 .h5p-content:has(.h5p-theme) .h5p-popup-dialog .h5p-inner > h2 {
@@ -42,7 +57,7 @@
 .h5p-content:has(.h5p-theme) .h5p-popup-dialog.h5p-open .h5p-scroll-content {
   padding: var(--h5p-theme-spacing-xl) var(--h5p-theme-spacing-l) var(--h5p-theme-spacing-l) var(--h5p-theme-spacing-l);
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(var(--button-count, 2), 1fr);
   background: var(--h5p-theme-ui-base);
   border-radius: var(--h5p-theme-border-radius-large);
   grid-gap: var(--h5p-theme-spacing-s);
@@ -106,7 +121,7 @@
 }
 
 .h5p-content:has(.h5p-theme) .h5p-popup-dialog .h5p-horizontal-line-text {
-  display: none;
+  display: var(--h5p-horizontal-line-text-display, none);
 }
 
 .h5p-content:has(.h5p-theme) .h5p-popup-dialog .h5p-big-button:before {
@@ -131,6 +146,7 @@
   padding: var(--h5p-theme-spacing-m);
   background: var(--h5p-theme-ui-base);
   border: solid 2px var(--h5p-theme-stroke-2);
+  max-width: 20rem;
 }
 
 .h5p-content:has(.h5p-theme) .h5p-popup-dialog .h5p-copy-button:before {
@@ -155,4 +171,22 @@
 .h5p-content:has(.h5p-theme) .h5p-popup-dialog .h5p-big-button:hover .h5p-button-title,
 .h5p-content:has(.h5p-theme) .h5p-popup-dialog .h5p-big-button:hover .h5p-button-description {
   color: var(--h5p-theme-contrast-cta);
+}
+
+@container h5p-popup-dialog (width < 480px) {
+  .h5p-content:has(.h5p-theme) .h5p-reuse-dialog .h5p-inner {
+    --h5p-horizontal-line-text-display: block;
+  }
+
+  .h5p-content:has(.h5p-theme) .h5p-popup-dialog .h5p-big-button {
+    max-width: 100%;
+  }
+
+  .h5p-content:has(.h5p-theme) .h5p-popup-dialog .h5p-horizontal-line-text {
+    display: block;
+  }
+
+  .h5p-content:has(.h5p-theme) .h5p-popup-dialog.h5p-open .h5p-scroll-content {
+      grid-template-columns: auto;
+  }
 }


### PR DESCRIPTION
When merged in, will
- fit the content if just one button is inside reuse dialog,
- let the “More info” text use the main-cta-base color,
- remove separator between header and content, and
- wrap buttons on smaller width screens.