### PR TITLE
HFP-4290 Add --h5p-theme-secondary-contrast-cta-hover to theme-variables

### DIFF
--- a/styles/h5p-theme-variables.css
+++ b/styles/h5p-theme-variables.css
@@ -15,6 +15,7 @@
   --h5p-theme-secondary-cta-light: #101b59;
   --h5p-theme-secondary-cta-dark: #090f34;
   --h5p-theme-secondary-contrast-cta: #e7eafa;
+  --h5p-theme-secondary-contrast-cta-hover: #e7eafa;
 
   --h5p-theme-alternative-light: #F8F9FE;
   --h5p-theme-alternative-dark: #DCDFFA;


### PR DESCRIPTION
After adding the --h5p-theme-secondary-contrast-cta-hover, now it is working fine.

<img width="281" height="224" alt="image" src="https://github.com/user-attachments/assets/9e8aa6e4-07d9-45c9-ad1e-bd8d2b1ffede" />