### PR TITLE
VA-1124 Don't show tooltip for disabled elements

### DIFF
--- a/js/h5p-tooltip.js
+++ b/js/h5p-tooltip.js
@@ -160,6 +160,10 @@ H5P.Tooltip = (function () {
      * @param {UIEvent} event The triggering event
      */
     const showTooltip = function (event, wait = true) {
+      if (!event.target || event.target.disabled) {
+        return;
+      }
+
       clearTimeout(hideTooltipTimer); // Prevent from hiding while supposed to show
 
       if (wait === true) {


### PR DESCRIPTION
When merged in, will no longer show the tooltip for elements that bear the `disabled` attribute.