### PR TITLE
VA-1124 Stop showing tooltip on aria-disabled element

### DIFF
--- a/js/h5p-tooltip.js
+++ b/js/h5p-tooltip.js
@@ -160,7 +160,7 @@ H5P.Tooltip = (function () {
      * @param {UIEvent} event The triggering event
      */
     const showTooltip = function (event, wait = true) {
-      if (!event.target || event.target.disabled) {
+      if (!event.target || event.target.disabled || event.target.getAttribute('aria-disabled') === 'true') {
         return;
       }
 


### PR DESCRIPTION
When merged in, will stop showing the tooltip for elements that bear the `aria-disabled` attribute.