### PR TITLE
Get rid of table borders, resolves #272.

### DIFF
--- a/js/h5p-utils.js
+++ b/js/h5p-utils.js
@@ -8,7 +8,7 @@ var H5PUtils = H5PUtils || {};
    * @param {array} headers List of headers
    */
   H5PUtils.createTable = function (headers) {
-    var $table = $('<table class="h5p-admin-table' + (H5PAdminIntegration.extraTableClasses !== undefined ? ' ' + H5PAdminIntegration.extraTableClasses : '') + '"></table>');
+    var $table = $('<table class="h5p-admin-table' + (H5PAdminIntegration.extraTableClasses !== undefined ? ' ' + H5PAdminIntegration.extraTableClasses : '') + ' table-reboot"></table>');
 
     if (headers) {
       var $thead = $('<thead></thead>');


### PR DESCRIPTION
Note this needs Moodle 5.0.3 which introduced the table-reboot class.