### PR TITLE
Add check for array_key_exists

### DIFF
--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -1028,11 +1028,16 @@ class H5PValidator {
           }
         }
         while ($missingLibraries = $this->getMissingLibraries($upgrades)) {
+          $foundOne = false;
           foreach ($missingLibraries as $libString => $missing) {
-            $library = $libraries[$libString];
-            if ($library) {
-              $upgrades[$libString] = $library;
+            if (array_key_exists($libString, $libraries)) {
+              $upgrades[$libString] = $libraries[$libString];
+              $foundOne = true;
             }
+          }
+          // Break if we didn't find any new libraries to add (prevents infinite loop)
+          if (!$foundOne) {
+            break;
           }
         }
 


### PR DESCRIPTION
The current code assumes every dependency returned by `getMissingLibraries()` exists in the uploaded package's $libraries array, which is not true. As a result `$libraries[libString]` may not exist.