### PR TITLE
AU-7752 Add filtered hash to content

### DIFF
--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -2197,9 +2197,6 @@ class H5PCore {
       $content['id'] = $this->h5pF->insertContent($content, $contentMainId);
     }
 
-    // Some user data for content has to be reset when the content changes.
-    $this->h5pF->resetContentUserData($contentMainId ? $contentMainId : $content['id']);
-
     return $content['id'];
   }
 
@@ -2302,6 +2299,9 @@ class H5PCore {
       $this->h5pF->deleteLibraryUsage($content['id']);
       $this->h5pF->saveLibraryUsage($content['id'], $content['dependencies']);
 
+      // Invalidate user data that depends on content params
+      $this->h5pF->resetContentUserData($content['id']);
+
       if (!$content['slug']) {
         $content['slug'] = $this->generateContentSlug($content);
 
@@ -2319,6 +2319,7 @@ class H5PCore {
       // Cache.
       $this->h5pF->updateContentFields($content['id'], array(
         'filtered' => $params,
+        'filtered_hash' => hash('sha256', $params),
         'slug' => $content['slug']
       ));
     }

--- a/js/h5p.js
+++ b/js/h5p.js
@@ -2408,7 +2408,8 @@ H5P.createTitle = function (rawTitle, maxLength) {
       options.data = {
         data: (data === null ? 0 : data),
         preload: (preload ? 1 : 0),
-        invalidate: (invalidate ? 1 : 0)
+        invalidate: (invalidate ? 1 : 0),
+        contentHash: (invalidate && H5PIntegration.contents['cid-' + contentId].jsonContentHash ? H5PIntegration.contents['cid-' + contentId].jsonContentHash : 0)
       };
     }
     else {


### PR DESCRIPTION
This is used to determine if the content has changed since it was loaded. This is to mitigate issues with storing old content user state after the content was updated.