### PR TITLE
Fix TypeError when processing non-array semantics fields

### DIFF
--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -4709,50 +4709,52 @@ class H5PContentValidator {
     $field = null;
 
     $isSubContent = isset($semantics->isSubContent) && $semantics->isSubContent === TRUE;
-
-    if (count($semantics->fields) == 1 && $flatten && !$isSubContent) {
-      $field = $semantics->fields[0];
-      $function = $this->typeMap[$field->type];
-      $this->$function($group, $field);
-    }
-    else {
-      foreach ($group as $key => &$value) {
-        // If subContentId is set, keep value
-        if($isSubContent && ($key == 'subContentId')){
-          continue;
-        }
-
-        // Find semantics for name=$key
-        $found = FALSE;
-        foreach ($semantics->fields as $field) {
-          if ($field->name == $key) {
-            if (isset($semantics->optional) && $semantics->optional) {
-              $field->optional = TRUE;
-            }
-            $function = $this->typeMap[$field->type];
-            $found = TRUE;
-            break;
+    
+    if (is_array($semantics->fields)){
+      if (count($semantics->fields) == 1 && $flatten && !$isSubContent) {
+        $field = $semantics->fields[0];
+        $function = $this->typeMap[$field->type];
+        $this->$function($group, $field);
+      }
+      else {
+        foreach ($group as $key => &$value) {
+          // If subContentId is set, keep value
+          if($isSubContent && ($key == 'subContentId')){
+            continue;
           }
-        }
-        if ($found) {
-          if ($function) {
-            $this->$function($value, $field);
-            if ($value === NULL) {
+
+          // Find semantics for name=$key
+          $found = FALSE;
+          foreach ($semantics->fields as $field) {
+            if ($field->name == $key) {
+              if (isset($semantics->optional) && $semantics->optional) {
+                $field->optional = TRUE;
+              }
+              $function = $this->typeMap[$field->type];
+              $found = TRUE;
+              break;
+            }
+          }
+          if ($found) {
+            if ($function) {
+              $this->$function($value, $field);
+              if ($value === NULL) {
+                unset($group->$key);
+              }
+            }
+            else {
+              // We have a field type in semantics for which we don't have a
+              // known validator.
+              $this->h5pF->setErrorMessage($this->h5pF->t('H5P internal error: unknown content type "@type" in semantics. Removing content!', array('@type' => $field->type)), 'semantics-unknown-type');
               unset($group->$key);
             }
           }
           else {
-            // We have a field type in semantics for which we don't have a
-            // known validator.
-            $this->h5pF->setErrorMessage($this->h5pF->t('H5P internal error: unknown content type "@type" in semantics. Removing content!', array('@type' => $field->type)), 'semantics-unknown-type');
+            // If validator is not found, something exists in content that does
+            // not have a corresponding semantics field. Remove it.
+            // $this->h5pF->setErrorMessage($this->h5pF->t('H5P internal error: no validator exists for @key', array('@key' => $key)));
             unset($group->$key);
           }
-        }
-        else {
-          // If validator is not found, something exists in content that does
-          // not have a corresponding semantics field. Remove it.
-          // $this->h5pF->setErrorMessage($this->h5pF->t('H5P internal error: no validator exists for @key', array('@key' => $key)));
-          unset($group->$key);
         }
       }
     }


### PR DESCRIPTION
Ensures that `$semantics->fields` is an array before calling `count()` on it. This prevents a `TypeError` if the property is `null` or another non-countable type.

**Error:**
```
Fatal error: Uncaught TypeError: count(): Argument #1 ($value) 
must be of type Countable|array, null given 
in h5p-php-library\h5p.classes.php on line 4713
```

Image of error on site:
<img width="745" height="1256" alt="Screenshot 2026-05-08 145830" src="https://github.com/user-attachments/assets/02fc6663-20fd-4554-b272-1dbd687749fd" />


