### PR TITLE
HFP-4349 Add dark contrast CTA variable to theme variables

### DIFF
--- a/styles/h5p-theme-variables.css
+++ b/styles/h5p-theme-variables.css
@@ -11,7 +11,8 @@
   --h5p-theme-contrast-cta-white: #006FBF;
 
   --h5p-theme-contrast-cta-light: color-mix(in srgb, var(--h5p-theme-main-cta-base), transparent 90%);
-
+  --h5p-theme-contrast-cta-dark: #0094FE;
+	
   --h5p-theme-secondary-cta-light: #F5F7FA;
   --h5p-theme-secondary-cta-dark: #D3DCE9;
   --h5p-theme-secondary-contrast-cta: #202122;


### PR DESCRIPTION
When merged in, will add `--h5p-theme-contrast-cta-dark`.

The value will be computed if a theme is chosen on H5P.com, but it will be missing on other H5P integrations that do not offer a color picker and rely on what H5P core sets.

The value that is set by this pull request was computed following the instructions at https://github.com/h5p/h5p-components/blob/master/Documentation/other-commonalities/variables.md#colors.