### PR TITLE
Validate the H5P title as Unicode characters, not bytes

### DIFF
--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -685,7 +685,7 @@ class H5PValidator {
 
   // Schemas used to validate the h5p files
   private $h5pRequired = array(
-    'title' => '/^.{1,255}$/',
+    'title' => '/^.{1,255}$/u',
     'language' => '/^[-a-zA-Z]{1,10}$/',
     'preloadedDependencies' => array(
       'machineName' => '/^[\w0-9\-\.]{1,255}$/i',
@@ -731,7 +731,7 @@ class H5PValidator {
 
   // Schemas used to validate the library files
   private $libraryRequired = array(
-    'title' => '/^.{1,255}$/',
+    'title' => '/^.{1,255}$/u',
     'majorVersion' => '/^[0-9]{1,5}$/',
     'minorVersion' => '/^[0-9]{1,5}$/',
     'patchVersion' => '/^[0-9]{1,5}$/',

--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -1395,7 +1395,7 @@ class H5PValidator {
       else {
         // The requirement is a regexp, match it against the data
         if (is_string($h5pData) || is_int($h5pData)) {
-          if (preg_match($requirement, $h5pData) === 0) {
+          if (preg_match($requirement, $h5pData) !== 1) {
              $this->h5pF->setErrorMessage($this->h5pF->t("Invalid data provided for %property in %library", array('%property' => $property_name, '%library' => $library_name)));
              $valid = FALSE;
           }


### PR DESCRIPTION
Hey folks,

A title made of non-Latin characters can be rejected even when it's well under the length limit. The validation pattern `/^.{1,255}$/` counts bytes, not characters, so a multibyte title (Japanese or Arabic, say) hits the 255 cap at around 85 characters. Adding the `u` modifier makes the quantifier count Unicode characters, which is what the 255 limit is meant to mean. This matches the linked Moodle report (MDL-87358).

I applied it to both title patterns: the content title in `$h5pRequired` that the report points at, and the library title in `$libraryRequired` a few lines down, which carries the identical byte-counting pattern. One thing worth calling out: with `/u`, `preg_match` also rejects a title containing an invalid UTF-8 byte sequence, which the byte pattern silently accepted before. For JSON-sourced metadata that's the safer behaviour, but it is a change in behaviour.

There's no unit-test harness in the library, so here is the standalone check I used, which anyone can run in under a minute:

    $title = str_repeat("\xC3\xA9", 200); // 200 e-acute characters = 400 bytes
    var_dump(preg_match('/^.{1,255}$/',  $title)); // 0 - rejected on byte count
    var_dump(preg_match('/^.{1,255}$/u', $title)); // 1 - accepted on character count

Closes #276

(full disclosure: AI helped me identify the issue and verify my work)
