### PR TITLE
fix / Fix unlinking uploaded H5P file

### DIFF
--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -962,7 +962,7 @@ class H5PValidator {
         // This is a breaking error, there's no need to continue. (the rest of the files will fail as well)
         $this->h5pF->setErrorMessage($this->h5pF->t('Unable to read file from the package: %fileName', array('%fileName' => $fileName)), 'unable-to-read-package-file');
         $zip->close();
-        unlink($path);
+        unlink($tmpPath);
         H5PCore::deleteFileTree($tmpDir);
         return FALSE;
       }


### PR DESCRIPTION
Thank you for your interest in contributing to H5P! 🎉  
Please fill in the below sections to make your pull request:

**What kind of change does this PR introduce?**
Bug fix

**What is the current behaviour?**
When validating an uploaded H5P file, it's possible that the file cannot be read from properly. In that case, the current code tries to remove the file from a non-existent `$path` variable and the server will log a warning.

Cmp. https://github.com/h5p/h5p-php-library/issues/207

**What is the new behaviour?**
The correct path to the H5P file is used, so files will be removed properly.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
