### PR TITLE
Add guard for H5P files without libraries

### DIFF
--- a/h5p.classes.php
+++ b/h5p.classes.php
@@ -980,6 +980,11 @@ class H5PValidator {
     $zip->close();
     unlink($tmpPath);
 
+    if (!is_dir($tmpDir)) {
+      $this->h5pF->setErrorMessage($this->h5pF->t('The package does not contain any libraries that could be installed'), 'no-libraries-in-package');
+      return FALSE;
+    }
+    
     if ($canInstall) {
       // Process and validate libraries using the unpacked library folders
       $files = scandir($tmpDir);


### PR DESCRIPTION
Thank you for your interest in contributing to H5P! 🎉  
Please fill in the below sections to make your pull request:

**What kind of change does this PR introduce?**
Bug fix

**What is the current behaviour?**
.h5p files usually contain libraries, but they do not necessarily need to. For instance, download one of the example files from h5p.org. They do not contain libraries.

When you upload such a file on the library settings page, e.g. on WordPress, then H5P core will try to validate the package but assume that libraries are contained and scan the upload directory unconditionally (https://github.com/h5p/h5p-php-library/blob/master/h5p.classes.php#L985). `$tmpDir` will not be set, however, as it's only created if there are libraries to be installed (in https://github.com/h5p/h5p-php-library/blob/master/h5p.classes.php#L971).

As a consequence, the PHP error log will be added a warning like `scandir(...): Failed to open directory: No such file or directory in ...`

**What is the new behaviour?**
A guard will check whether there are libraries that can be installed and return an error message if there's none.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
